### PR TITLE
Support custom data for Raygun Handler

### DIFF
--- a/src/Graze/Monolog/Handler/RaygunHandler.php
+++ b/src/Graze/Monolog/Handler/RaygunHandler.php
@@ -42,11 +42,21 @@ class RaygunHandler extends AbstractProcessingHandler
     protected function write(array $record)
     {
         $context = $record['context'];
-
+        $tags = $customData = $timestamp = null;
+        if (array_key_exists('tags', $context) && is_array($context['tags'])) {
+            $tags = $context['tags'];
+        }
+        if (array_key_exists('custom_data', $context) && is_array($context['custom_data'])) {
+            $customData = $context['custom_data'];
+        }
+        if (array_key_exists('timestamp', $context) && is_numeric($context['timestamp'])) {
+            $timestamp = $context['timestamp'];
+        }
+        
         if (isset($context['exception']) && $context['exception'] instanceof \Exception) {
-            $this->writeException($record);
+            $this->writeException($record, $tags, $customData, $timestamp);
         } elseif (isset($context['file']) && $context['line']) {
-            $this->writeError($record);
+            $this->writeError($record, $tags, $customData, $timestamp);
         } else {
             throw new \InvalidArgumentException('Invalid record given.');
         }
@@ -55,23 +65,26 @@ class RaygunHandler extends AbstractProcessingHandler
     /**
      * @param array $record
      */
-    protected function writeError(array $record)
+    protected function writeError(array $record, $tags = null, $customData = null, $timestamp = null)
     {
         $context = $record['context'];
         $this->client->SendError(
             0,
             $record['message'],
             $context['file'],
-            $context['line']
+            $context['line'],
+            $tags,
+            $customData,
+            $timestamp
         );
     }
 
     /**
      * @param array $record
      */
-    protected function writeException(array $record)
+    protected function writeException(array $record, $tags = null, $customData = null, $timestamp = null)
     {
-        $this->client->SendException($record['context']['exception']);
+        $this->client->SendException($record['context']['exception'], $tags, $customData, $timestamp);
     }
 
     /**
@@ -82,3 +95,4 @@ class RaygunHandler extends AbstractProcessingHandler
         return new NormalizerFormatter();
     }
 }
+

--- a/src/Graze/Monolog/Handler/RaygunHandler.php
+++ b/src/Graze/Monolog/Handler/RaygunHandler.php
@@ -42,7 +42,10 @@ class RaygunHandler extends AbstractProcessingHandler
     protected function write(array $record)
     {
         $context = $record['context'];
-        $tags = $customData = $timestamp = null;
+        $tags = array();
+        $customData = array();
+        $timestamp = null;
+        
         if (array_key_exists('tags', $context) && is_array($context['tags'])) {
             $tags = $context['tags'];
         }
@@ -64,8 +67,11 @@ class RaygunHandler extends AbstractProcessingHandler
 
     /**
      * @param array $record
+     * @param array $tags
+     * @param array $customData
+     * @param int|float $timestamp
      */
-    protected function writeError(array $record, $tags = null, $customData = null, $timestamp = null)
+    protected function writeError(array $record, array $tags, array $customData, $timestamp = null)
     {
         $context = $record['context'];
         $this->client->SendError(
@@ -81,8 +87,11 @@ class RaygunHandler extends AbstractProcessingHandler
 
     /**
      * @param array $record
+     * @param array $tags
+     * @param array $customData
+     * @param int|float $timestamp
      */
-    protected function writeException(array $record, $tags = null, $customData = null, $timestamp = null)
+    protected function writeException(array $record, array $tags, array $customData, $timestamp = null)
     {
         $this->client->SendException($record['context']['exception'], $tags, $customData, $timestamp);
     }

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -33,7 +33,16 @@ class RaygunHandlerTest extends TestCase
 
     public function testHandleError()
     {
-        $record = $this->getRecord(300, 'foo', array('file' => 'bar', 'line' => 1));
+        $record = $this->getRecord(300,
+            'foo',
+            array(
+                'file' => 'bar',
+                'line' => 1,
+                'tags' => ['foo', 'bar'],
+                'custom_data' => ['bar' => 'baz'],
+                'timestamp' => 1234567890,
+            )
+        );
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
         $handler = new RaygunHandler($this->client);
         $handler->setFormatter($formatter);
@@ -46,7 +55,7 @@ class RaygunHandlerTest extends TestCase
         $this->client
              ->shouldReceive('SendError')
              ->once()
-             ->with(0, 'foo', 'bar', 1);
+             ->with(0, 'foo', 'bar', 1, ['foo', 'bar'], ['bar' => 'baz'], 1234567890);
 
         $handler->handle($record);
     }
@@ -54,7 +63,15 @@ class RaygunHandlerTest extends TestCase
     public function testHandleException()
     {
         $exception = new \Exception('foo');
-        $record = $this->getRecord(300, 'foo', array('exception' => $exception));
+        $record = $this->getRecord(300,
+            'foo',
+            array(
+                'exception' => $exception,
+                'tags' => ['foo', 'bar'],
+                'custom_data' => ['bar' => 'baz'],
+                'timestamp' => 1234567890,
+            )
+        );
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
         $handler = new RaygunHandler($this->client);
         $handler->setFormatter($formatter);
@@ -67,7 +84,7 @@ class RaygunHandlerTest extends TestCase
         $this->client
              ->shouldReceive('SendException')
              ->once()
-             ->with($exception);
+             ->with($exception, ['foo', 'bar'], ['bar' => 'baz'], 1234567890);
 
         $handler->handle($record);
     }

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -38,8 +38,8 @@ class RaygunHandlerTest extends TestCase
             array(
                 'file' => 'bar',
                 'line' => 1,
-                'tags' => ['foo', 'bar'],
-                'custom_data' => ['bar' => 'baz'],
+                'tags' => array('foo', 'bar'),
+                'custom_data' => array('bar' => 'baz'),
                 'timestamp' => 1234567890,
             )
         );
@@ -55,7 +55,7 @@ class RaygunHandlerTest extends TestCase
         $this->client
              ->shouldReceive('SendError')
              ->once()
-             ->with(0, 'foo', 'bar', 1, ['foo', 'bar'], ['bar' => 'baz'], 1234567890);
+             ->with(0, 'foo', 'bar', 1, array('foo', 'bar'), array('bar' => 'baz'), 1234567890);
 
         $handler->handle($record);
     }
@@ -67,8 +67,8 @@ class RaygunHandlerTest extends TestCase
             'foo',
             array(
                 'exception' => $exception,
-                'tags' => ['foo', 'bar'],
-                'custom_data' => ['bar' => 'baz'],
+                'tags' => array('foo', 'bar'),
+                'custom_data' => array('bar' => 'baz'),
                 'timestamp' => 1234567890,
             )
         );
@@ -84,7 +84,7 @@ class RaygunHandlerTest extends TestCase
         $this->client
              ->shouldReceive('SendException')
              ->once()
-             ->with($exception, ['foo', 'bar'], ['bar' => 'baz'], 1234567890);
+             ->with($exception, array('foo', 'bar'), array('bar' => 'baz'), 1234567890);
 
         $handler->handle($record);
     }


### PR DESCRIPTION
Raygun allows sending extra data to the client. This PR allows you to send that data to Raygun using the appropriate keys.