### PR TITLE
Support custom data for Raygun Handler

### DIFF
--- a/src/Graze/Monolog/Formatter/RaygunFormatter.php
+++ b/src/Graze/Monolog/Formatter/RaygunFormatter.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * This file is part of Monolog Extensions
+ *
+ * Copyright (c) 2014 Nature Delivered Ltd. <http://graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see  http://github.com/graze/MonologExtensions/blob/master/LICENSE
+ * @link http://github.com/graze/MonologExtensions
+ */
+namespace Graze\Monolog\Formatter;
+
+use Monolog\Formatter\NormalizerFormatter;
+
+class RaygunFormatter extends NormalizerFormatter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function format(array $record)
+    {
+        $record['tags'] = array();
+        $record['custom_data'] = array();
+        $record['timestamp'] = null;
+
+        foreach (array('extra', 'context') as $source) {
+            if (array_key_exists('tags', $record[$source]) && is_array($record[$source]['tags'])) {
+                $record['tags'] = array_merge($record['tags'], $record[$source]['tags']);
+            }
+            if (array_key_exists('timestamp', $record[$source]) && is_numeric($record[$source]['timestamp'])) {
+                $record['timestamp'] = $record[$source]['timestamp'];
+            }
+            unset($record[$source]['tags'], $record[$source]['timestamp']);
+        }
+
+        $record['custom_data'] = $record['extra'];
+        $record['extra'] = array();
+        foreach ($record['context'] as $key => $item) {
+            if (!in_array($key, array('file', 'line', 'exception'))) {
+                $record['custom_data'][$key] = $item;
+                unset($record['context'][$key]);
+            }
+        }
+
+        return $record;
+    }
+}

--- a/tests/unit/src/Graze/Monolog/Formatter/RaygunFormatterTest.php
+++ b/tests/unit/src/Graze/Monolog/Formatter/RaygunFormatterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Graze\Monolog\Formatter;
+
+use Monolog\TestCase;
+
+class RaygunFormatterTest extends TestCase
+{
+    public function logData()
+    {
+        return array(
+            array(
+                array_merge_recursive(
+                    $baseRecord = $this->getRecord(300,
+                        'foo', array(
+                            'file' => 'bar',
+                            'line' => 1,
+                        )
+                    ),
+                    array(
+                        'context' => array(
+                            'bar' => 'baz',
+                            'timestamp' => 1234567890,
+                            'tags' => array('foo'),
+                        ),
+                        'extra' => array(
+                            'baz' => 'qux',
+                            'tags' => array('bar'),
+                        )
+                    )
+                ),
+                array_merge(
+                    $baseRecord,
+                    array(
+                        'tags' => array('bar', 'foo'),
+                        'timestamp' => 1234567890,
+                        'custom_data' => array('bar' => 'baz', 'baz' => 'qux'),
+                    )
+                )
+            ),
+            array(
+                array_merge_recursive(
+                    $baseRecord = $this->getRecord(300, 'foo', array('exception' => new \Exception('foo'))),
+                    array(
+                        'extra' => array(
+                            'bar' => 'baz',
+                            'tags' => array('foo', 'bar'),
+                            'timestamp' => 1234567890,
+                        )
+                    )
+                ),
+                array_merge(
+                    $baseRecord,
+                    array(
+                        'tags' => array('foo', 'bar'),
+                        'timestamp' => 1234567890,
+                        'custom_data' => array('bar' => 'baz'),
+                    )
+                )
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider logData
+     * @param array $input
+     * @param array $expected
+     */
+    public function testFormat(array $input, array $expected)
+    {
+        $formatter = new RaygunFormatter();
+        $this->assertEquals($expected, $formatter->format($input));
+    }
+}

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -37,11 +37,18 @@ class RaygunHandlerTest extends TestCase
             'foo', array(
                 'file' => 'bar',
                 'line' => 1,
-                'tags' => array('foo'),
-                'timestamp' => 1234567890,
             )
         );
+        $record['context']['tags'] = array('foo');
+        $record['context']['timestamp'] = 1234567890;
         $record['extra'] = array('bar' => 'baz', 'tags' => array('bar'));
+        $formatted = array_merge($record,
+            array(
+                'tags' => array('foo', 'bar'),
+                'timestamp' => 1234567890,
+                'custom_data' => array('bar' => 'baz')
+            )
+        );
 
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
         $handler = new RaygunHandler($this->client);
@@ -51,11 +58,11 @@ class RaygunHandlerTest extends TestCase
              ->shouldReceive('format')
              ->once()
              ->with($record)
-             ->andReturn(array());
+             ->andReturn($formatted);
         $this->client
              ->shouldReceive('SendError')
              ->once()
-             ->with(0, 'foo', 'bar', 1, array('bar', 'foo'), array('bar' => 'baz'), 1234567890);
+             ->with(0, 'foo', 'bar', 1, array('foo', 'bar'), array('bar' => 'baz'), 1234567890);
 
         $handler->handle($record);
     }
@@ -66,6 +73,13 @@ class RaygunHandlerTest extends TestCase
         $record = $this->getRecord(300, 'foo', array('exception' => $exception));
         $record['extra'] = array('bar' => 'baz', 'tags' => array('foo', 'bar'));
         $record['extra']['timestamp'] = 1234567890;
+        $formatted = array_merge($record,
+            array(
+                'tags' => array('foo', 'bar'),
+                'timestamp' => 1234567890,
+                'custom_data' => array('bar' => 'baz')
+            )
+        );
 
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
         $handler = new RaygunHandler($this->client);
@@ -75,7 +89,7 @@ class RaygunHandlerTest extends TestCase
              ->shouldReceive('format')
              ->once()
              ->with($record)
-             ->andReturn(array());
+             ->andReturn($formatted);
         $this->client
              ->shouldReceive('SendException')
              ->once()

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -33,7 +33,16 @@ class RaygunHandlerTest extends TestCase
 
     public function testHandleError()
     {
-        $record = $this->getRecord(300, 'foo', array('file' => 'bar', 'line' => 1));
+        $record = $this->getRecord(300,
+            'foo', array(
+                'file' => 'bar',
+                'line' => 1,
+                'tags' => array('foo'),
+                'timestamp' => 1234567890,
+            )
+        );
+        $record['extra'] = array('bar' => 'baz', 'tags' => array('bar'));
+
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
         $handler = new RaygunHandler($this->client);
         $handler->setFormatter($formatter);
@@ -46,7 +55,7 @@ class RaygunHandlerTest extends TestCase
         $this->client
              ->shouldReceive('SendError')
              ->once()
-             ->with(0, 'foo', 'bar', 1);
+             ->with(0, 'foo', 'bar', 1, array('bar', 'foo'), array('bar' => 'baz'), 1234567890);
 
         $handler->handle($record);
     }
@@ -55,6 +64,9 @@ class RaygunHandlerTest extends TestCase
     {
         $exception = new \Exception('foo');
         $record = $this->getRecord(300, 'foo', array('exception' => $exception));
+        $record['extra'] = array('bar' => 'baz', 'tags' => array('foo', 'bar'));
+        $record['extra']['timestamp'] = 1234567890;
+
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
         $handler = new RaygunHandler($this->client);
         $handler->setFormatter($formatter);
@@ -67,7 +79,7 @@ class RaygunHandlerTest extends TestCase
         $this->client
              ->shouldReceive('SendException')
              ->once()
-             ->with($exception);
+             ->with($exception, array('foo', 'bar'), array('bar' => 'baz'), 1234567890);
 
         $handler->handle($record);
     }


### PR DESCRIPTION
Second try. This time using the data from the context and extra arrays directly. This is similar to how other handlers work, such as the New Relic or Raven handler.