### PR TITLE
Make Raygun formatter actually call NormalizerFormatter

### DIFF
--- a/src/Graze/Monolog/Formatter/RaygunFormatter.php
+++ b/src/Graze/Monolog/Formatter/RaygunFormatter.php
@@ -21,6 +21,8 @@ class RaygunFormatter extends NormalizerFormatter
      */
     public function format(array $record)
     {
+        $record = parent::format($record);
+
         $record['tags'] = array();
         $record['custom_data'] = array();
         $record['timestamp'] = null;

--- a/src/Graze/Monolog/Handler/RaygunHandler.php
+++ b/src/Graze/Monolog/Handler/RaygunHandler.php
@@ -45,7 +45,7 @@ class RaygunHandler extends AbstractProcessingHandler
 
         if (isset($context['exception']) && $context['exception'] instanceof \Exception) {
             $this->writeException(
-                $record['formatted'],
+                $record,
                 $record['formatted']['tags'],
                 $record['formatted']['custom_data'],
                 $record['formatted']['timestamp']

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -80,6 +80,12 @@ class RaygunHandlerTest extends TestCase
                 'custom_data' => array('bar' => 'baz')
             )
         );
+        $formatted['context']['exception'] = array(
+            'class' => get_class($exception),
+            'message' => $exception->getMessage(),
+            'code' => $exception->getCode(),
+            'file' => $exception->getFile().':'.$exception->getLine(),
+        );
 
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
         $handler = new RaygunHandler($this->client);


### PR DESCRIPTION
When I implemented the Raygun Formatter in #12, I forgot to make it call its parent. I fixed that, and updated the test accordingly. I split up the test for regular errors and exceptions into their own tests as the normalizer does things to exceptions that I needed to test separately.

I also revert to sending the non-formatted message as the first argument to SendError/Exception as the NormalizerFormatter converts Exceptions to arrays. I updated the handler test to reflect this