### PR TITLE
Support Throwable on PHP 7 for Raygun Handler

### DIFF
--- a/src/Graze/Monolog/Handler/RaygunHandler.php
+++ b/src/Graze/Monolog/Handler/RaygunHandler.php
@@ -43,7 +43,12 @@ class RaygunHandler extends AbstractProcessingHandler
     {
         $context = $record['context'];
 
-        if (isset($context['exception']) && $context['exception'] instanceof \Exception) {
+        if (isset($context['exception']) &&
+            (
+                $context['exception'] instanceof \Exception ||
+                (PHP_VERSION_ID > 70000 && $context['exception'] instanceof \Throwable)
+            )
+        ) {
             $this->writeException(
                 $record['formatted'],
                 $record['formatted']['tags'],

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -97,4 +97,37 @@ class RaygunHandlerTest extends TestCase
 
         $handler->handle($record);
     }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testHandleThrowable()
+    {
+        $exception = new \TypeError('foo');
+        $record = $this->getRecord(300, 'foo', array('exception' => $exception));
+        $record['context']['tags'] = array('foo');
+        $formatted = array_merge($record,
+            array(
+                'tags' => array('foo'),
+                'custom_data' => array(),
+                'timestamp' => null,
+            )
+        );
+
+        $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
+        $handler = new RaygunHandler($this->client);
+        $handler->setFormatter($formatter);
+
+        $formatter
+            ->shouldReceive('format')
+            ->once()
+            ->with($record)
+            ->andReturn($formatted);
+        $this->client
+            ->shouldReceive('SendException')
+            ->once()
+            ->with($exception, array('foo'), array(), null);
+
+        $handler->handle($record);
+    }
 }


### PR DESCRIPTION
Like I said, here's the PR to allow the Raygun handler to accept Throwable types on PHP 7. If you aren't running PHP 7, the handler should function exactly the same as it does without this PR. I also added a unit test that will be skipped on PHP < 7. Travis was also updated to add PHP 5.6 and 7 support, so CI will work with that test.