### PR TITLE
Raygun - correct level support

### DIFF
--- a/src/Graze/Monolog/Handler/RaygunHandler.php
+++ b/src/Graze/Monolog/Handler/RaygunHandler.php
@@ -17,6 +17,9 @@ use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use Raygun4php\RaygunClient;
 
+/**
+ * RaygunHandler for Raygun Client. Only supports Level >= NOTICE.
+ */
 class RaygunHandler extends AbstractProcessingHandler
 {
     /**
@@ -32,8 +35,15 @@ class RaygunHandler extends AbstractProcessingHandler
     public function __construct(RaygunClient $client, $level = Logger::DEBUG, $bubble = true)
     {
         $this->client = $client;
-
         parent::__construct($level, $bubble);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isHandling(array $record)
+    {
+        return $record['level'] >= Logger::NOTICE && $record['level'] >= $this->level;
     }
 
     /**
@@ -42,7 +52,6 @@ class RaygunHandler extends AbstractProcessingHandler
     protected function write(array $record)
     {
         $context = $record['context'];
-
         if (isset($context['exception']) &&
             (
                 $context['exception'] instanceof \Exception ||

--- a/src/Graze/Monolog/Handler/RaygunHandler.php
+++ b/src/Graze/Monolog/Handler/RaygunHandler.php
@@ -64,16 +64,20 @@ class RaygunHandler extends AbstractProcessingHandler
                 $record['formatted']['custom_data'],
                 $record['formatted']['timestamp']
             );
-        } elseif (isset($context['file']) && $context['line']) {
+            return;
+        }
+
+        if (isset($context['file']) && $context['line']) {
             $this->writeError(
                 $record['formatted'],
                 $record['formatted']['tags'],
                 $record['formatted']['custom_data'],
                 $record['formatted']['timestamp']
             );
-        } else {
-            throw new \InvalidArgumentException('Invalid record given.');
+            return;
         }
+
+        throw new \InvalidArgumentException('attempt to handle unsupported record type');
     }
 
     /**
@@ -115,4 +119,3 @@ class RaygunHandler extends AbstractProcessingHandler
         return new RaygunFormatter();
     }
 }
-

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -136,4 +136,32 @@ class RaygunHandlerTest extends TestCase
 
         $handler->handle($record);
     }
+
+    /**
+     * @dataProvider dataProviderIsHandling
+     * @param int $handlerLevel
+     * @param int $recordLevel
+     * @param bool $isHandlingExpected
+     */
+    public function testIsHandling($handlerLevel, $recordLevel, $isHandlingExpected)
+    {
+        $handler = new RaygunHandler($this->client, $handlerLevel);
+        $record = ['level' => $recordLevel];
+
+        $this->assertEquals($isHandlingExpected, $handler->isHandling($record));
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderIsHandling()
+    {   // handler level, record level, isHandling expected
+        return [
+            [100, 100, false], // DEBUG
+            [100, 200, false], // INFO
+            [100, 250, true], // NOTICE
+            [100, 300, true], // WARNING
+            [300, 250, false], // NOTICE
+        ];
+    }
 }


### PR DESCRIPTION
The `RaygunHandler` only supports log levels >= `NOTICE`. 
Do not attempt to support log levels less than `NOTICE`.