### PR TITLE
Ensure RaygunHandler only handles valid records

### DIFF
--- a/src/Graze/Monolog/Handler/RaygunHandler.php
+++ b/src/Graze/Monolog/Handler/RaygunHandler.php
@@ -37,6 +37,28 @@ class RaygunHandler extends AbstractProcessingHandler
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function isHandling(array $record)
+    {
+        if(parent::isHandling($record)) {
+            $context = $record['context'];
+
+            //Ensure only valid records will be handled and no InvalidArgumentException will be thrown
+            if ((isset($context['exception']) &&
+                    (
+                        $context['exception'] instanceof \Exception ||
+                        (PHP_VERSION_ID > 70000 && $context['exception'] instanceof \Throwable)
+                    )
+                ) || (isset($context['file']) && $context['line'])
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @param array $record
      */
     protected function write(array $record)

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -104,6 +104,28 @@ class RaygunHandlerTest extends TestCase
         $handler->handle($record);
     }
 
+    public function testIsHandling()
+    {
+        $handler = new RaygunHandler($this->client);
+
+        $exception = new \Exception('foo');
+        $handlingRecord1 = $this->getRecord(300, 'foo', array('exception' => $exception));
+
+        $this->assertTrue($handler->isHandling($handlingRecord1));
+
+        $context = array(
+            'file' => $exception->getFile(),
+            'line' => $exception->getLine(),
+        );
+        $handlingRecord2 = $this->getRecord(300, 'bar', $context);
+        $this->assertTrue($handler->isHandling($handlingRecord2));
+
+
+        $nonHandlingRecord = $this->getRecord(300, 'baz', array());
+        $this->assertFalse($handler->isHandling($nonHandlingRecord));
+        $this->assertFalse($handler->handle($nonHandlingRecord));
+    }
+
     /**
      * @requires PHP 7
      */


### PR DESCRIPTION
RaygunHandler currently only handles writing records with a context array containing either an exception (either _\Exception_ or _\Thorwable_) object or one with a _file_ and _line_ key set. Otherwise an _InvalidArgumentException_ will be thrown in the _write_ method.
Valid structures for context arrays are one of:
- **['file' => 'filename', 'line' => 0]**
- **['exception' => new Exception('message')]**

This change implements an extended **isHandling** method checking the appropriate **record format** the RaygunHandler write method can handle.
The interface for this is defined in  _Monolog\Handler\HandlerInterface_ and implemented in _Monolog\Handler\AbstractHandler_.