### PR TITLE
be defensive on context existence

### DIFF
--- a/src/Graze/Monolog/Handler/RaygunHandler.php
+++ b/src/Graze/Monolog/Handler/RaygunHandler.php
@@ -41,7 +41,7 @@ class RaygunHandler extends AbstractProcessingHandler
      */
     public function isHandling(array $record)
     {
-        if (parent::isHandling($record)) {
+        if (parent::isHandling($record) && isset($record['context'])) {
             $context = $record['context'];
 
             //Ensure only valid records will be handled and no InvalidArgumentException will be thrown


### PR DESCRIPTION
**Problem:**

If you call `RaygunHandler` with a record with no context at all, it will throw a NOTICE, as it assumes it is set.

**Solution**

1. `isset ($record['context']`

**QA**

1. `make build test`