### PR TITLE
remove code from isHandling, but dont throw exception on non handling

### DIFF
--- a/tests/integration/src/Graze/Monolog/Handler/RaygunHandlerIntegrationTest.php
+++ b/tests/integration/src/Graze/Monolog/Handler/RaygunHandlerIntegrationTest.php
@@ -3,7 +3,6 @@
 namespace Graze\Monolog\Handler;
 
 use Mockery;
-use Mockery\MockInterface;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Raygun4php\RaygunClient;
@@ -13,7 +12,7 @@ class RaygunHandlerIntegrationTest extends TestCase
 {
     /** @var Logger */
     private $logger;
-    /** @var RaygunClient|MockInterface */
+    /** @var mixed */
     private $raygun;
     /** @var RaygunHandler */
     private $handler;

--- a/tests/integration/src/Graze/Monolog/Handler/RaygunHandlerIntegrationTest.php
+++ b/tests/integration/src/Graze/Monolog/Handler/RaygunHandlerIntegrationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Graze\Monolog\Handler;
+
+use Mockery;
+use Mockery\MockInterface;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Raygun4php\RaygunClient;
+use RuntimeException;
+
+class RaygunHandlerIntegrationTest extends TestCase
+{
+    /** @var Logger */
+    private $logger;
+    /** @var RaygunClient|MockInterface */
+    private $raygun;
+    /** @var RaygunHandler */
+    private $handler;
+
+    public function setUp()
+    {
+        $this->raygun = Mockery::mock(RaygunClient::class);
+        $this->handler = new RaygunHandler($this->raygun, Logger::NOTICE);
+        $this->logger = new Logger('raygunHandlerTest', [$this->handler]);
+    }
+
+    public function testErrorWithExceptionTriggersLogger()
+    {
+        $exception = new RuntimeException('test exception');
+
+        $this->raygun
+            ->shouldReceive('SendException')
+            ->once()
+            ->with($exception, [], [], null);
+
+        $this->logger->error('test error', ['exception' => $exception]);
+    }
+
+    public function testErrorWithErrorWillTriggerLogger()
+    {
+        $this->raygun
+            ->shouldReceive('SendError')
+            ->once()
+            ->with(0, "test line error", __FILE__, 5, [], [], null);
+        $this->logger->error('test line error', ['file' => __FILE__, 'line' => 5]);
+    }
+
+    public function testErrorWithNoLineWillDoNothing()
+    {
+        $this->logger->error('test line error', ['file' => __FILE__]);
+    }
+
+    public function testErrorWithNoFileWillDoNothing()
+    {
+        $this->logger->error('test line error', ['line' => __FILE__]);
+    }
+
+    public function testErrorWithNeitherWillDoNothing()
+    {
+        $this->logger->error('test line error');
+    }
+}

--- a/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
+++ b/tests/unit/src/Graze/Monolog/Handler/RaygunHandlerTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Graze\Monolog\Handler;
 
 use Mockery as m;
-use Monolog\Logger;
 use Monolog\TestCase;
 
 class RaygunHandlerTest extends TestCase
@@ -35,20 +35,21 @@ class RaygunHandlerTest extends TestCase
     public function testHandleError()
     {
         $record = $this->getRecord(300,
-            'foo', array(
+            'foo',
+            [
                 'file' => 'bar',
                 'line' => 1,
-            )
+            ]
         );
-        $record['context']['tags'] = array('foo');
+        $record['context']['tags'] = ['foo'];
         $record['context']['timestamp'] = 1234567890;
-        $record['extra'] = array('bar' => 'baz', 'tags' => array('bar'));
+        $record['extra'] = ['bar' => 'baz', 'tags' => ['bar']];
         $formatted = array_merge($record,
-            array(
-                'tags' => array('foo', 'bar'),
-                'timestamp' => 1234567890,
-                'custom_data' => array('bar' => 'baz')
-            )
+            [
+                'tags'        => ['foo', 'bar'],
+                'timestamp'   => 1234567890,
+                'custom_data' => ['bar' => 'baz'],
+            ]
         );
 
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
@@ -56,14 +57,14 @@ class RaygunHandlerTest extends TestCase
         $handler->setFormatter($formatter);
 
         $formatter
-             ->shouldReceive('format')
-             ->once()
-             ->with($record)
-             ->andReturn($formatted);
+            ->shouldReceive('format')
+            ->once()
+            ->with($record)
+            ->andReturn($formatted);
         $this->client
-             ->shouldReceive('SendError')
-             ->once()
-             ->with(0, 'foo', 'bar', 1, array('foo', 'bar'), array('bar' => 'baz'), 1234567890);
+            ->shouldReceive('SendError')
+            ->once()
+            ->with(0, 'foo', 'bar', 1, ['foo', 'bar'], ['bar' => 'baz'], 1234567890);
 
         $handler->handle($record);
     }
@@ -71,36 +72,36 @@ class RaygunHandlerTest extends TestCase
     public function testHandleException()
     {
         $exception = new \Exception('foo');
-        $record = $this->getRecord(300, 'foo', array('exception' => $exception));
-        $record['extra'] = array('bar' => 'baz', 'tags' => array('foo', 'bar'));
+        $record = $this->getRecord(300, 'foo', ['exception' => $exception]);
+        $record['extra'] = ['bar' => 'baz', 'tags' => ['foo', 'bar']];
         $record['extra']['timestamp'] = 1234567890;
         $formatted = array_merge($record,
-            array(
-                'tags' => array('foo', 'bar'),
-                'timestamp' => 1234567890,
-                'custom_data' => array('bar' => 'baz')
-            )
+            [
+                'tags'        => ['foo', 'bar'],
+                'timestamp'   => 1234567890,
+                'custom_data' => ['bar' => 'baz'],
+            ]
         );
-        $formatted['context']['exception'] = array(
-            'class' => get_class($exception),
+        $formatted['context']['exception'] = [
+            'class'   => get_class($exception),
             'message' => $exception->getMessage(),
-            'code' => $exception->getCode(),
-            'file' => $exception->getFile().':'.$exception->getLine(),
-        );
+            'code'    => $exception->getCode(),
+            'file'    => $exception->getFile() . ':' . $exception->getLine(),
+        ];
 
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
         $handler = new RaygunHandler($this->client);
         $handler->setFormatter($formatter);
 
         $formatter
-             ->shouldReceive('format')
-             ->once()
-             ->with($record)
-             ->andReturn($formatted);
+            ->shouldReceive('format')
+            ->once()
+            ->with($record)
+            ->andReturn($formatted);
         $this->client
-             ->shouldReceive('SendException')
-             ->once()
-             ->with($exception, array('foo', 'bar'), array('bar' => 'baz'), 1234567890);
+            ->shouldReceive('SendException')
+            ->once()
+            ->with($exception, ['foo', 'bar'], ['bar' => 'baz'], 1234567890);
 
         $handler->handle($record);
     }
@@ -108,14 +109,14 @@ class RaygunHandlerTest extends TestCase
     public function testHandleEmptyDoesNothing()
     {
         $record = $this->getRecord(300, 'bar');
-        $record['extra'] = array('bar' => 'baz', 'tags' => array('foo', 'bar'));
+        $record['extra'] = ['bar' => 'baz', 'tags' => ['foo', 'bar']];
         $record['extra']['timestamp'] = 1234567890;
         $formatted = array_merge($record,
-            array(
-                'tags' => array('foo', 'bar'),
-                'timestamp' => 1234567890,
-                'custom_data' => array('bar' => 'baz')
-            )
+            [
+                'tags'        => ['foo', 'bar'],
+                'timestamp'   => 1234567890,
+                'custom_data' => ['bar' => 'baz'],
+            ]
         );
 
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
@@ -137,14 +138,14 @@ class RaygunHandlerTest extends TestCase
     public function testHandleThrowable()
     {
         $exception = new \TypeError('foo');
-        $record = $this->getRecord(300, 'foo', array('exception' => $exception));
-        $record['context']['tags'] = array('foo');
+        $record = $this->getRecord(300, 'foo', ['exception' => $exception]);
+        $record['context']['tags'] = ['foo'];
         $formatted = array_merge($record,
-            array(
-                'tags' => array('foo'),
-                'custom_data' => array(),
-                'timestamp' => null,
-            )
+            [
+                'tags'        => ['foo'],
+                'custom_data' => [],
+                'timestamp'   => null,
+            ]
         );
 
         $formatter = m::mock('Monolog\\Formatter\\FormatterInterface');
@@ -159,7 +160,7 @@ class RaygunHandlerTest extends TestCase
         $this->client
             ->shouldReceive('SendException')
             ->once()
-            ->with($exception, array('foo'), array(), null);
+            ->with($exception, ['foo'], [], null);
 
         $handler->handle($record);
     }


### PR DESCRIPTION
Resolves #25 

When raygun handler is called first, isHandling only includes a record with `['level' => 100]` (or whatever), thus exception and file/line checking does not happen.